### PR TITLE
Update webserver-configuration.md

### DIFF
--- a/_documentation/webserver-configuration.md
+++ b/_documentation/webserver-configuration.md
@@ -38,7 +38,7 @@ which needs to be allowed by Apache via `AllowOverride All`.
         AllowOverride All
 
         # If you see an error like the following in your logs:
-        # AH01630: client denied by server configuration: /var/www/kimai/public/
+        # AH01630: client denied by server configuration: /var/www/kimai2/public/
         # then you might have to exchange the "Order/Allow" rules with "Require" (see below)
         # More infos at https://httpd.apache.org/docs/2.4/de/upgrading.html
 

--- a/_documentation/webserver-configuration.md
+++ b/_documentation/webserver-configuration.md
@@ -33,8 +33,8 @@ which needs to be allowed by Apache via `AllowOverride All`.
     ServerName kimai.local
     ServerAlias www.kimai.local
 
-    DocumentRoot /var/www/kimai/public
-    <Directory /var/www/kimai/public>
+    DocumentRoot /var/www/kimai2/public
+    <Directory /var/www/kimai2/public>
         AllowOverride All
 
         # If you see an error like the following in your logs:
@@ -52,14 +52,14 @@ which needs to be allowed by Apache via `AllowOverride All`.
         FallbackResource /index.php
     </Directory>
 
-    <Directory /var/www/kimai>
+    <Directory /var/www/kimai2>
         Options FollowSymlinks
     </Directory>
 
     # optionally disable the fallback resource for the asset directories
     # which will allow Apache to return a 404 error when files are
     # not found instead of passing the request to Symfony
-    <Directory /var/www/kimai/public/bundles>
+    <Directory /var/www/kimai2/public/bundles>
         FallbackResource disabled
     </Directory>
     


### PR DESCRIPTION
Directory path is inconsistent with https://www.kimai.org/documentation/installation.html where the `./kimai2` directory is explicitly mentioned, this change replaces all `*/kimai/*` directories with `*/kimai2/*` to be consistent with the git pull instruction of the installation guide.