### PR TITLE
Double words removed

### DIFF
--- a/_documentation/activity.md
+++ b/_documentation/activity.md
@@ -40,7 +40,7 @@ Please note:
 - all currently linked objects will still show the activity in the dropdown as pre-selected option
   - you can still change the activity on timesheet record, which used it before
   - you cannot create new timesheet records for this activity 
-- you can still access the hidden entries by changing the visibility filter on the the toolbars 
+- you can still access the hidden entries by changing the visibility filter on the toolbars
 
 The visibility filter in the toolbar has three state: 
 - Visible: Yes (all activities that are "really" visible, meaning: the activity, linked project and customer are visible)

--- a/_documentation/backups.md
+++ b/_documentation/backups.md
@@ -75,7 +75,7 @@ Now you [can upgrade]({% link _documentation/updates.md %}) :-)
 
 You restored Kimai (as documented above), but have problems when accessing it?
 
-Maybe you have have missed an upgrade steps, which you would have done when executing a [normal upgrade]({% link _documentation/updates.md %}).
+Maybe you have missed an upgrade steps, which you would have done when executing a [normal upgrade]({% link _documentation/updates.md %}).
 
 Please check the [UPGRADING]({{ site.kimai_v2_file }}/UPGRADING.md) guide and make sure you executed all version specific tasks.
 

--- a/_documentation/customer.md
+++ b/_documentation/customer.md
@@ -55,7 +55,7 @@ Please note:
   - you can still change the customer on timesheet records and projects, which used it before
   - you cannot create new projects for this customer
   - you cannot create new timesheet records for this customer 
-- you can still access the hidden entries by changing the visibility filter on the the toolbars 
+- you can still access the hidden entries by changing the visibility filter on the toolbars
 
 The visibility filter in the toolbar has three state: 
 - Visible: Yes (all customers that are visible)

--- a/_documentation/meta-fields.md
+++ b/_documentation/meta-fields.md
@@ -106,7 +106,7 @@ Attention: `setLabel()` and `setOptions()` will be added with 1.4.
 ### Displaying and exporting custom fields
 
 With Kimai 1.4 you can display and export custom fields. 
-Supported fields will be shown as new columns in the the data-tables for timesheets, customers, projects and activities. 
+Supported fields will be shown as new columns in the data-tables for timesheets, customers, projects and activities.
 Additionally these fields will be added to HTML and Spreadsheet exports. 
 
 As Kimai cannot query all existing records for possible custom fields, you need to listen to new events and 

--- a/_documentation/migration-v1.md
+++ b/_documentation/migration-v1.md
@@ -41,7 +41,7 @@ You can install it on the same server, but remember that you have to meet the se
 After Kimai 2 runs properly, the actual *migration* takes place, by importing the data from your Kimai 1 database into Kimai 2.
 You have to have SSH access to your server, as you will use a command shipped with Kimai 2, which will pull the data into the configured database from your `.env` file.
 
-The database does not have to be on the same server and the the database user (for the Kimai 1 tables) needs only read access.
+The database does not have to be on the same server and the database user (for the Kimai 1 tables) needs only read access.
      
 ## Database import
 

--- a/_documentation/project.md
+++ b/_documentation/project.md
@@ -33,7 +33,7 @@ Please note:
   - you can still change the project on timesheet records and activities, which used it before
   - you cannot create new activities for this project
   - you cannot create new timesheet records for this project 
-- you can still access the hidden entries by changing the visibility filter on the the toolbars 
+- you can still access the hidden entries by changing the visibility filter on the toolbars
 
 The visibility filter in the toolbar has three state: 
 - Visible: Yes (all projects that are "really" visible, meaning: the project and linked customer are visible)

--- a/_documentation/updates.md
+++ b/_documentation/updates.md
@@ -22,7 +22,7 @@ git fetch --tags
 git checkout {{ site.kimai_v2_version }}
 ```
 
-You might have to prefix the the next commands with `sudo` and/or `php73` (depends on your environment):
+You might have to prefix the next commands with `sudo` and/or `php73` (depends on your environment):
 
 Update all composer dependencies:
 ```bash

--- a/_documentation/user-preferences.md
+++ b/_documentation/user-preferences.md
@@ -130,7 +130,7 @@ class UserProfileSubscriber implements EventSubscriberInterface
 ### Displaying and exporting UserPreferences 
 
 With Kimai 1.4 you can display and export user preferences. 
-Supported fields will be shown as new columns in the the data-table for users.
+Supported fields will be shown as new columns in the data-table for users.
 Additionally these preferences will be added to HTML and Spreadsheet exports. 
 
 As Kimai cannot query all existing users for possible preferences, you need to listen to a new event and register the desired preference. 

--- a/_documentation/webserver-configuration.md
+++ b/_documentation/webserver-configuration.md
@@ -5,7 +5,7 @@ toc: true
 ---
 
 If you can't manage to get Kimai up and running, it is very likely not an issue with Kimai.
-- Check your server logs first and the the Kimai logs (at `var/logs/` inside the Kimai directory).
+- Check your server logs first and the Kimai logs (at `var/logs/` inside the Kimai directory).
 - Try to find an answer at Stackoverflow, ServerFault or other online communities
 
 The following configurations are meant to give you a first idea how your config could look like, 


### PR DESCRIPTION
Double words "the the" and "have have" was removed. Checked by native English speaker.

Also, in https://github.com/kimai/www.kimai.org/blob/master/_documentation/backups.md is wording 
> missed an upgrade steps

which should be one of:
- missed an upgrade step
- missed upgrade steps

depending on whether only 1 or more steps was missed.