### PR TITLE
Public function name corrected and required use statement added.

### DIFF
--- a/_documentation/reporting.md
+++ b/_documentation/reporting.md
@@ -54,6 +54,7 @@ You can add your own views to the reporting panel by listening to the `Reporting
 namespace KimaiPlugin\DemoBundle\EventSubscriber;
 
 use App\Event\ReportingEvent;
+use App\Reporting\Report;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
@@ -73,7 +74,7 @@ final class ReportingEventSubscriber implements EventSubscriberInterface
         ];
     }
 
-    public function onMainMenuConfigure(ReportingEvent $event)
+    public function onReportingMenu(ReportingEvent $event)
     {
         // perform your necessary permission checks
         if (!$this->security->isGranted('view_reporting')) {


### PR DESCRIPTION
In the Kimai Reporting Documentation Extending the reports section at
https://www.kimai.org/documentation/reporting.html#extending-the-reports I have correced the following two inaccuracies

public function onMainMenuConfigure(ReportingEvent $event)
should be
public function onReportingMenu(ReportingEvent $event)
in ReportingEventSubscriber.php
2.use App\Reporting\Report; is also required in ReportingEventSubscriber.php