### PR TITLE
Update webserver-configuration.md

### DIFF
--- a/_documentation/webserver-configuration.md
+++ b/_documentation/webserver-configuration.md
@@ -39,8 +39,8 @@ server {
     location ~ ^/index\.php(/|$) {
         fastcgi_pass unix:/run/php/php7.2-fpm.sock;
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
-        include fastcgi.conf; # Or you path to fascgi params file
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name; # If not put this line get error FastCGI "Primary script unknown" 
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param PHP_ADMIN_VALUE "open_basedir=$document_root/..:/tmp/";
         internal;
     }

--- a/_documentation/webserver-configuration.md
+++ b/_documentation/webserver-configuration.md
@@ -40,7 +40,16 @@ server {
         fastcgi_pass unix:/run/php/php7.2-fpm.sock;
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        # You can use the document root directly:
+        # fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+
+        # But this is not working in every situation. When you are using symlinks to link the document 
+        # root to the current version of your application, you should pass the real
+        # application path instead of the path to the symlink to PHP FPM.
+        # Otherwise, PHP's OPcache may not properly detect changes to your PHP files 
+        # (see https://github.com/zendtech/ZendOptimizerPlus/issues/126 for more information).
+        fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+        fastcgi_param DOCUMENT_ROOT $realpath_root;
         fastcgi_param PHP_ADMIN_VALUE "open_basedir=$document_root/..:/tmp/";
         internal;
     }

--- a/_documentation/webserver-configuration.md
+++ b/_documentation/webserver-configuration.md
@@ -39,7 +39,8 @@ server {
     location ~ ^/index\.php(/|$) {
         fastcgi_pass unix:/run/php/php7.2-fpm.sock;
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
-        include fastcgi.conf;
+        include fastcgi.conf; # Or you path to fascgi params file
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name; # If not put this line get error FastCGI "Primary script unknown" 
         fastcgi_param PHP_ADMIN_VALUE "open_basedir=$document_root/..:/tmp/";
         internal;
     }


### PR DESCRIPTION
If not add `fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name` get error `2734 FastCGI sent in stderr: "Primary script unknown" while reading response header from upstream...`
Also fastcgi.conf usually is named fastcgi_params on nginx install from source.