### PR TITLE
Include /auth/saml/ in baseurl for keycloak example

### DIFF
--- a/_documentation/keycloak.md
+++ b/_documentation/keycloak.md
@@ -68,7 +68,7 @@ kimai:
                     binding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
                 #privateKey: ''
             # only set baseurl, if auto-detection doesn't work
-            #baseurl: 'https://kimai.domain.de'
+            #baseurl: 'https://kimai.domain.de/auth/saml/'
             strict: true
             debug: true
             security:


### PR DESCRIPTION
This should be correct in most cases and also how the azure example shows the baseurl