### PR TITLE
Source, title and description missmatch in plugin

### DIFF
--- a/_store/de/keleo-task-management-bundle.md
+++ b/_store/de/keleo-task-management-bundle.md
@@ -13,12 +13,12 @@ screenshots:
     description: "The new administration page with an overview of all tasks with tracked times, status and assignments"
   - 
     src: "/images/marketplace/tasks-create.png"
-    title: Task widgets
-    description: "The new dashboard widgets for assigned and pending tasks"
-  - 
-    src: "/images/marketplace/tasks-widget.png"
     title: "Edit a task"
     description: "When creating or updating a task, you can record these fields"
+  - 
+    src: "/images/marketplace/tasks-widget.png"
+    title: Task widgets
+    description: "The new dashboard widgets for assigned and pending tasks"
 lang: de
 permalink: /de/store/keleo-task-management-bundle.html
 ---

--- a/_store/fr/keleo-task-management-bundle.md
+++ b/_store/fr/keleo-task-management-bundle.md
@@ -13,12 +13,12 @@ screenshots:
     description: "The new administration page with an overview of all tasks with tracked times, status and assignments"
   - 
     src: "/images/marketplace/tasks-create.png"
-    title: Task widgets
-    description: "The new dashboard widgets for assigned and pending tasks"
-  - 
-    src: "/images/marketplace/tasks-widget.png"
     title: "Edit a task"
     description: "When creating or updating a task, you can record these fields"
+  - 
+    src: "/images/marketplace/tasks-widget.png"
+    title: Task widgets
+    description: "The new dashboard widgets for assigned and pending tasks"
 lang: fr
 permalink: /fr/store/keleo-task-management-bundle.html
 ---

--- a/_store/hr/keleo-task-management-bundle.md
+++ b/_store/hr/keleo-task-management-bundle.md
@@ -13,12 +13,12 @@ screenshots:
     description: "The new administration page with an overview of all tasks with tracked times, status and assignments"
   - 
     src: "/images/marketplace/tasks-create.png"
-    title: Task widgets
-    description: "The new dashboard widgets for assigned and pending tasks"
-  - 
-    src: "/images/marketplace/tasks-widget.png"
     title: "Edit a task"
     description: "When creating or updating a task, you can record these fields"
+  - 
+    src: "/images/marketplace/tasks-widget.png"
+    title: Task widgets
+    description: "The new dashboard widgets for assigned and pending tasks"
 lang: hr
 permalink: /hr/store/keleo-task-management-bundle.html
 ---

--- a/_store/keleo-task-management-bundle.md
+++ b/_store/keleo-task-management-bundle.md
@@ -13,12 +13,12 @@ screenshots:
     description: "The new administration page with an overview of all tasks with tracked times, status and assignments"
   - 
     src: "/images/marketplace/tasks-create.png"
-    title: Task widgets
-    description: "The new dashboard widgets for assigned and pending tasks"
-  - 
-    src: "/images/marketplace/tasks-widget.png"
     title: "Edit a task"
     description: "When creating or updating a task, you can record these fields"
+  - 
+    src: "/images/marketplace/tasks-widget.png"
+    title: Task widgets
+    description: "The new dashboard widgets for assigned and pending tasks"
 lang: en
 ---
 


### PR DESCRIPTION
IMO, the "title" and "description" strings of src: "/images/marketplace/tasks-create.png" and src: "/images/marketplace/tasks-widget.png" sould be swapped