### PR TITLE
Update documentation: `setSection` is deprecated

### DIFF
--- a/_documentation/developers.md
+++ b/_documentation/developers.md
@@ -555,8 +555,7 @@ class MySubscriber implements EventSubscriberInterface
 
     public function onSystemConfiguration(SystemConfigurationEvent $event)
     {
-        $event->addConfiguration((new SystemConfigurationModel())
-            ->setSection('your_bundle')
+        $event->addConfiguration((new SystemConfigurationModel('your_bundle'))
             ->setConfiguration([
                 (new Configuration())
                     ->setName('your.setting')


### PR DESCRIPTION
The `setSection` method in `SystemConfiguration` is marked as deprecated, but it's still used in the `_documentation/developers.md` page.

https://github.com/kimai/www.kimai.org/blob/b74c54119e93c1950927f840586f57d978c0df1d/_documentation/developers.md?plain=1#L559

https://github.com/kevinpapst/kimai2/blob/96d0d4943bef39ee09e3069ed89ee60e90aca60a/src/Form/Model/SystemConfiguration.php#L62-L67