### PR TITLE
Update to Azure SAML setup

### DIFF
--- a/_documentation/saml-azure.md
+++ b/_documentation/saml-azure.md
@@ -59,7 +59,7 @@ Adjust the following keys with your Azure / App specific settings:
 kimai:
     saml:
         activate: true
-        title: Login with Azure
+        title: Login with AzureAD
         mapping:
             - { saml: $http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name, kimai: username }
             - { saml: $http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress, kimai: email }
@@ -97,25 +97,18 @@ title: Login with Azure
 entityId: 'https://sts.windows.net/****-****-***/'                # Azure AD Identifier
 singleSignOnService:
     url: 'https://login.microsoftonline.com/****-****-***/saml2'  # Login URL
-    binding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
-singleLogoutService:
-    url: 'https://login.microsoftonline.com/****-****-***/saml2'  # Logout URL
-    binding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
 ```
 
-3. Change the **sp** configuration:
+3. Change the **sp** configuration replacing **https://timetracking.example.com** with your Kimai URL:
 ```yaml
 entityId: 'https://timetracking.example.com/auth/saml/metadata'
 assertionConsumerService:
     url: 'https://timetracking.example.com/auth/saml/acs'
-    binding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST'
-# logout does not seem to work properly
-#singleLogoutService:
-#    url: 'https://timetracking.example.com/auth/saml/logout'
-#    binding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
+singleLogoutService:
+    url: 'https://timetracking.example.com/auth/saml/logout'
 ```
 
-4. Change the **x509cert** by opening the earlier downloaded certificate and copy it, without “Next-line” Enters into the configuration:
+4. Change the **x509cert** by opening the earlier downloaded certificate file (in a text editor) and copy the content to the config file and change it to one line  by removing the first line (BEGIN CERTIFICATE) and the last line (END CERTIFICATE) and then removing all line-breaks.
 ```yaml
 x509cert:  'REALLY LONG SET OF CHARACTERS'
 ```
@@ -130,4 +123,4 @@ x509cert:  'REALLY LONG SET OF CHARACTERS'
 4. Please click on the Kimai application , we called it **Kimai**, and then navigate to **Users and groups** on the left navigation bar.
 5. Click on **Add user/group** and add the groups or users, who should have access.
 
-You should now be able to test the Login by visiting **https://timetracking.example.com/** and clicking on the title of the SAML method, you defined earlier.
+You should now be able to test the Login by visiting your Kimai URL and clicking on the title of the SAML method, you defined earlier.

--- a/_documentation/saml-azure.md
+++ b/_documentation/saml-azure.md
@@ -65,7 +65,6 @@ kimai:
             - { saml: $http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress, kimai: email }
             - { saml: $http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname $http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname, kimai: alias }
             - { saml: $http://schemas.xmlsoap.org/ws/2005/05/identity/claims/displayname, kimai: title }
-            - { saml: $http://schemas.xmlsoap.org/ws/2005/05/identity/claims/employeeid, kimai: accountNumber }
         roles:
             resetOnLogin: true
             attribute: http://schemas.microsoft.com/ws/2008/06/identity/claims/groups
@@ -84,6 +83,8 @@ kimai:
                     url: 'https://timetracking.example.com/auth/saml/acs'
                 singleLogoutService:
                     url: 'https://timetracking.example.com/auth/saml/logout'
+            security:
+                requestedAuthnContext: false
 ```
 
 1. Change the title to the wanted text on the login screen


### PR DESCRIPTION
I just managed to setup AzureAD SAML auth with kimai and I recommend some improvments to the Azure saml setup documentation:

- I would suggest to remove
`- { saml: $http://schemas.xmlsoap.org/ws/2005/05/identity/claims/employeeid, kimai: accountNumber }`
since "employeeid" does not exists by default in azure ad (I had php 500 errors with employeeid "Missing user attribute")

 - I suggest adding 
 ```
 security:
                 requestedAuthnContext: false
 ```
 so that the login also works with edge browser where users are already signed in to Microsoft 365 via the Windows settings and don't (can't) use a password
 
- on step two I suggest to remove singleLogoutService since its not present in the example config above and I also don't recommend using it because on kimai logout you normally don't want to get logged out of Microsoft 365 as well
 
- updated config at the steps to be consistent with the default config from above
 
- added some clarification to the x509cert config step