### PR TITLE
owlysk-codetimer added github link

### DIFF
--- a/_data/store/owlysk-codetimer.yml
+++ b/_data/store/owlysk-codetimer.yml
@@ -1,5 +1,6 @@
 developer: owlysk
 icon: fas fa-desktop
+github: https://github.com/owlysk/CodeTimer
 price: 0
 new: true
 screenshots:


### PR DESCRIPTION
Hi, I forgot to add github link to my plugin, so I added now