### PR TITLE
feat: create automated pull requests for new Kimai Versions

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -10,12 +10,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: "Update kimai version in _config.yml"
+      - name: "Update Kimai version in _config.yml"
         run: scripts/update-version-number.sh "${{ github.event.client_payload.kimai_version }}"
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
-          commit-message: "docs: update kimai_2_version to ${{ github.event.client_payload.kimai_version }}"
-          title: "docs: update kimai_2_version to ${{ github.event.client_payload.kimai_version }}"
-          branch: "docs/update-kimai-to-${{ github.event.client_payload.kimai_version }}"
+          commit-message: "Bump latest release to ${{ github.event.client_payload.kimai_version }}"
+          title: "Bump version to ${{ github.event.client_payload.kimai_version }}"
+          branch: "docs/release-${{ github.event.client_payload.kimai_version }}"

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -8,5 +8,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: "Save version number"
-        run: echo "${{steps.remote_version.outputs.version}}"
+      - uses: actions/checkout@v3
+
+      - name: "Update kimai version in _config.yml"
+        run: scripts/update-version-number.sh "${{ github.event.client_payload.kimai_version }}"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: "docs: update kimai_2_version to ${{ github.event.client_payload.kimai_version }}"
+          title: "docs: update kimai_2_version to ${{ github.event.client_payload.kimai_version }}"
+          branch: "docs/update-kimai-to-${{ github.event.client_payload.kimai_version }}"

--- a/scripts/update-version-number.sh
+++ b/scripts/update-version-number.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+
+set -e
+
+CONFIG_FILE="_config.yml"
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <new_value>"
+    exit 1
+fi
+
+new_value="$1"
+
+# Use awk to update the kimai_v2_version value in the CONFIG_FILE
+awk -v new_version="$new_value" '/kimai_v2_version:/ {$2 = "\"" new_version "\""} 1' "$CONFIG_FILE" > temp.yml && mv temp.yml "$CONFIG_FILE"
+
+echo "Updated $CONFIG_FILE: Set kimai_v2_version to '$new_value'"


### PR DESCRIPTION
This PR uses the `peter-evans/create-pull-request` action to create a new Pull Request and a simple script based on `awk` to update the version number in `_config.yml`.

In the current `version.yml` workflow, you used `${{steps.remote_version.outputs.version}}` to get the version number. I'm not sure where this comes from. Therefore, I've adjusted the action to expect a payload `kimai_version` containing the new kimai version. 

Since this requires a small change to the workflow in `kimai/kimai` I've created a small Pull Request for the changes there as well: https://github.com/kimai/kimai/pull/4248 

I've tested this on my fork, by sending the Webhook for the `repository_dispatch` manually using this script:

```bash
#!/usr/bin/env sh

set -e

if [ $# -ne 2 ]; then
    echo "Usage: $0 <github-token> <new_value>"
    exit 1
fi

token="$1"
new_value="$2"

curl -L \
  -X POST \
  -H "Accept: application/vnd.github+json" \
  -H "Authorization: Bearer ${token}" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  https://api.github.com/repos/cngJo/www.kimai.org/dispatches \
  -d "{\"event_type\":\"kimai_release\",\"client_payload\":{\"kimai_version\":\"${new_value}\"}}"
```

```console
./test-send-webhook.sh <github-token> "2.0.31"
```

This created the following Pull Request: https://github.com/cngJo/www.kimai.org/pull/1

I've tried to use sensible defaults for commit messages and branch names. Please let me know when you have any other suggestions 😉

--- 

ATTENTION:

Please make sure the default `GITHUB_TOKEN` write access and permissions to create Pull Requests. 
See [Workflow Permissions](https://github.com/peter-evans/create-pull-request#workflow-permissions) in the [`create-pull-request`](https://github.com/peter-evans/create-pull-request) repo for more information.