### PR TITLE
Add nginx option to redirect from http to https.

### DIFF
--- a/_documentation/webserver-configuration.md
+++ b/_documentation/webserver-configuration.md
@@ -210,7 +210,7 @@ server {
           proxy_set_header  X-Forwarded-Proto $scheme;
           proxy_set_header  X-Forwarded-Port $server_port;
       }
-    # Redirect HTTP to HTTPS
+    # Redirect HTTP to HTTPS, in case an invalid (plain HTTP) request was sent to port 443
     error_page 497 https://$host:$server_port$request_uri;
 }
 ```

--- a/_documentation/webserver-configuration.md
+++ b/_documentation/webserver-configuration.md
@@ -209,7 +209,7 @@ server {
           proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
           proxy_set_header  X-Forwarded-Proto $scheme;
           proxy_set_header  X-Forwarded-Port $server_port;
-      }
+    }
     # Redirect HTTP to HTTPS, in case an invalid (plain HTTP) request was sent to port 443
     error_page 497 https://$host:$server_port$request_uri;
 }

--- a/_documentation/webserver-configuration.md
+++ b/_documentation/webserver-configuration.md
@@ -210,6 +210,8 @@ server {
           proxy_set_header  X-Forwarded-Proto $scheme;
           proxy_set_header  X-Forwarded-Port $server_port;
       }
+    # Redirect HTTP to HTTPS
+    error_page 497 https://$host:$server_port$request_uri;
 }
 ```
 


### PR DESCRIPTION
The server is redirecting the user to the http,
if the server is behind the proxy and uses https
it will return "400 bad request error".

This additional line fixes the problem.