### PR TITLE
bump required mysql version to 8.3

### DIFF
--- a/_documentation/developers.md
+++ b/_documentation/developers.md
@@ -18,9 +18,9 @@ This page is for all developers who want to contribute to Kimai. You rock!
 
 All you need is:
 
-- a recent PHP version, best is 8.1
+- a recent PHP version, best is 8.1+
 - some standard PHP extensions, see composer file for more infos
-- a MariaDB or MySQL instance
+- a MariaDB 11.1+ or MySQL 8.3+ instance
 - [Composer](https://getcomposer.org/download/) and `git`
 
 ## Development installation
@@ -37,7 +37,7 @@ You need to change your environment to `dev` and configure your database connect
 
 ```
 APP_ENV=dev
-DATABASE_URL=mysql://user:password@127.0.0.1:3306/database?charset=utf8mb4&serverVersion=5.7.40
+DATABASE_URL=mysql://user:password@127.0.0.1:3306/database?charset=utf8mb4&serverVersion=8.3.0
 ```
 
 The next command will import demo data, to test the application in its full beauty - with different user accounts,

--- a/_documentation/docker/docker-compose.md
+++ b/_documentation/docker/docker-compose.md
@@ -13,7 +13,7 @@ version: '3.5'
 services:
 
   sqldb:
-    image: mysql:5.7
+    image: mysql:8.3
     volumes:
       - mysql:/var/lib/mysql
     environment:
@@ -39,7 +39,7 @@ services:
     environment:
       - ADMINMAIL=admin@kimai.local
       - ADMINPASS=changemeplease
-      - "DATABASE_URL=mysql://kimaiuser:kimaipassword@sqldb/kimai?charset=utf8mb4&serverVersion=5.7.40"
+      - "DATABASE_URL=mysql://kimaiuser:kimaipassword@sqldb/kimai?charset=utf8mb4&serverVersion=8.3.0"
       - TRUSTED_HOSTS=nginx,localhost,127.0.0.1
     restart: unless-stopped
 
@@ -55,7 +55,7 @@ version: '3.5'
 services:
 
   sqldb:
-    image: mysql:5.7
+    image: mysql:8.3
     environment:
       - MYSQL_DATABASE=kimai
       - MYSQL_USER=kimaiuser
@@ -77,7 +77,7 @@ services:
     environment:
       - ADMINMAIL=admin@kimai.local
       - ADMINPASS=changemeplease
-      - "DATABASE_URL=mysql://kimaiuser:kimaipassword@sqldb/kimai?charset=utf8mb4&serverVersion=5.7.40"
+      - "DATABASE_URL=mysql://kimaiuser:kimaipassword@sqldb/kimai?charset=utf8mb4&serverVersion=8.3.0"
       - TRUSTED_HOSTS=nginx,localhost,127.0.0.1
     restart: unless-stopped
 ```
@@ -107,7 +107,7 @@ version: '3.5'
 services:
 
   sqldb:
-    image: mysql:5.7
+    image: mysql:8.3
     environment:
       - MYSQL_DATABASE=kimai
       - MYSQL_USER=kimaiuser
@@ -143,7 +143,7 @@ services:
     environment:
       - ADMINMAIL=admin@kimai.local
       - ADMINPASS=changemeplease
-      - "DATABASE_URL=mysql://kimaiuser:kimaipassword@sqldb/kimai?charset=utf8mb4&serverVersion=5.7.40"
+      - "DATABASE_URL=mysql://kimaiuser:kimaipassword@sqldb/kimai?charset=utf8mb4&serverVersion=8.3.0"
       - TRUSTED_HOSTS=nginx,localhost,127.0.0.1
     volumes:
       - public:/opt/kimai/public
@@ -165,7 +165,7 @@ version: '3.5'
 services:
 
   sqldb:
-    image: mysql:5.7
+    image: mysql:8.3
     environment:
       - MYSQL_DATABASE=kimai
       - MYSQL_USER=kimaiuser
@@ -203,7 +203,7 @@ services:
     environment:
       - ADMINMAIL=admin@kimai.local
       - ADMINPASS=changemeplease
-      - DATABASE_URL=mysql://kimaiuser:kimaipassword@sqldb/kimai?charset=utf8mb4&serverVersion=5.7.40
+      - DATABASE_URL=mysql://kimaiuser:kimaipassword@sqldb/kimai?charset=utf8mb4&serverVersion=8.3.0
       - TRUSTED_HOSTS=nginx,localhost,127.0.0.1
       - MAILER_URL=smtp://mailer:1025
       - MAILER_FROM=kimai@example.com
@@ -250,7 +250,7 @@ version: '3.5'
 services:
 
   sqldb:
-    image: mysql:5.7
+    image: mysql:8.3
     environment:
       - MYSQL_DATABASE=kimai
       - MYSQL_USER=kimaiuser
@@ -286,7 +286,7 @@ services:
     environment:
       - ADMINMAIL=admin@kimai.local
       - ADMINPASS=changemeplease
-      - "DATABASE_URL=mysql://kimaiuser:kimaipassword@sqldb/kimai?charset=utf8mb4&serverVersion=5.7.40"
+      - "DATABASE_URL=mysql://kimaiuser:kimaipassword@sqldb/kimai?charset=utf8mb4&serverVersion=8.3.0"
       - TRUSTED_HOSTS=nginx,localhost,127.0.0.1
     volumes:
       - public:/opt/kimai/public

--- a/_documentation/docker/docker.md
+++ b/_documentation/docker/docker.md
@@ -35,7 +35,7 @@ This will run the latest production build and make it accessible at <http://loca
     docker run --rm --name kimai-test \
         -ti \
         -p 8001:8001 \
-        -e DATABASE_URL=mysql://kimai:kimai@${HOSTNAME}:3399/kimai?charset=utf8mb4&serverVersion=5.7.40 \
+        -e DATABASE_URL=mysql://kimai:kimai@${HOSTNAME}:3399/kimai?charset=utf8mb4&serverVersion=8.3.0 \
         kimai/kimai2:apache
     ```
 
@@ -77,7 +77,7 @@ memory_limit=512M
 See the Kimai and Symfony docs for more info on these.
 
 ```bash
-DATABASE_URL=mysql://user:pass@hodt/dbname?charset=utf8mb4&serverVersion=5.7.40
+DATABASE_URL=mysql://user:pass@hodt/dbname?charset=utf8mb4&serverVersion=8.3.0
 APP_SECRET=change_this_to_something_unique
 TRUSTED_PROXIES=nginx,localhost,127.0.0.1
 TRUSTED_HOSTS=nginx,localhost,127.0.0.1

--- a/_documentation/installation.md
+++ b/_documentation/installation.md
@@ -155,12 +155,12 @@ An error like this might occur when you have a misconfigured `serverVersion` in 
 constraint violation: 1052 Column 'TABLE_NAME' in where clause is ambiguous
 ```
 
-Run `mysql --version` and extract the entire version string, for example for this entire version string: 
+Run `mysql --version` and extract the [entire version string](https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#automatic-platform-version-detection), for example for this version string: 
 ```
 mysql from 11.1.2-MariaDB, client 15.2 for osx10.19 (arm64) using  EditLine wrapper
 ```
 
-Your `serverVersion` should look like this:
+the `serverVersion` part in your `DATABASE_URL` should include the part `11.1.2-MariaDB` like this:
 ```
 DATABASE_URL=mysql://kimai:kimai@sqldb/kimai?charset=utf8mb4&serverVersion=11.1.2-MariaDB
 ```
@@ -192,7 +192,7 @@ mG0%2Fd1%403aT.Z%29s
 
 Then your `DATABASE_URL` might look like this:
 ```
-DATABASE_URL=mysql://root:mG0%2Fd1%403aT.Z%29s@127.0.0.1:3306/kimai2?charset=utf8mb4&serverVersion=5.7.40
+DATABASE_URL=mysql://root:mG0%2Fd1%403aT.Z%29s@127.0.0.1:3306/kimai2?charset=utf8mb4&serverVersion=8.3.0
 ```
 
 ### Which user to use, www-data, httpd or your own?

--- a/_documentation/webserver-configuration.md
+++ b/_documentation/webserver-configuration.md
@@ -116,7 +116,7 @@ which needs to be allowed by Apache via `AllowOverride All`.
     # optionally set the value of the environment variables used in the application
     #SetEnv APP_ENV prod
     #SetEnv APP_SECRET <app-secret-id>
-    #SetEnv DATABASE_URL "mysql://db_user:db_pass@host:3306/db_name?charset=utf8mb4&serverVersion=5.7.40"
+    #SetEnv DATABASE_URL "mysql://db_user:db_pass@host:3306/db_name?charset=utf8mb4&serverVersion=8.3.0"
 </VirtualHost>
 ```
 

--- a/_posts/2024-04-10-social-media-accounts.md
+++ b/_posts/2024-04-10-social-media-accounts.md
@@ -1,0 +1,29 @@
+---
+title: "Social media"
+date: "2024-04-10 20:00:00 +0200"
+image: /images/blog/cover-cloud.jpeg
+author: kevinpapst
+tags: [Cloud]
+---
+
+Exciting news!
+We've officially joined your favorite socials to bring you even more of what you love. 
+
+**Where you can find us**
+
+Follow us on [Facebook](https://www.facebook.com/people/Kimai/61557684102167/), 
+[Instagram](https://www.instagram.com/kimai_org), 
+[Twitter / X](https://twitter.com/kimai_org), and 
+[LinkedIn](https://www.linkedin.com/company/kimai-timetracker/) for software updates, demos, behind-the-scenes content, a quick laugh, special offers, and more!
+
+Stay connected and be part of our online community. Let's continue the journey together!
+
+**Collecting testimonials**
+
+We value your feedback! That’s why we’d like to kindly ask that you share your experience so far using Kimai and let us 
+know how it has helped you streamline your workflow, boost productivity, and achieve your goals. 
+
+Your testimonials help us improve and inspire others to discover the benefits of our software. 
+[Click here]() to submit your testimonial and be featured on our website. 
+
+Thank you for being part of our success story!


### PR DESCRIPTION
See https://github.com/kimai/kimai/discussions/4766
Not sure about the minor version in `serverVersion=8.3.0` I guess needs to be tested first...

@tobybatch @not-code opinions? is a mysql version update like that safe?
