### PR TITLE
chore: add UserReportingBundle to store

### DIFF
--- a/_data/de/store.yml
+++ b/_data/de/store.yml
@@ -122,6 +122,9 @@ items:
     owlysk-codetimer:
         title: CodeTimer - Desktop Widget
         intro: Desktop Widget für Kimai
+    helsinkisystems-userreporting:
+        title: Nutzer Berichte
+        intro: Detailierte Nutzer Berichte zu Tätigkeiten, Projekten und Kunden mit zusätzlichem Versand der Reports an E-Mail Addressen.
     helsinkisystems-budgetwatcher:
         title: Budget Überwachung
         intro: Versendet Benachrichtigungen, wenn eine konfigurierbare Budgetgrenze bei einem Projekt erreicht ist

--- a/_data/en/store.yml
+++ b/_data/en/store.yml
@@ -122,6 +122,9 @@ items:
     owlysk-codetimer:
         title: CodeTimer desktop widget
         intro: Desktop widget for Kimai
+    helsinkisystems-userreporting:
+        title: User Reporting
+        intro: See more detailed reports about activities, projects and customers with monthly reports by mail.
     helsinkisystems-budgetwatcher:
         title: Budget Watcher
         intro: Get notified whenever a certain amount of your projects budget is used

--- a/_data/store/helsinkisystems-userreporting.yaml
+++ b/_data/store/helsinkisystems-userreporting.yaml
@@ -1,0 +1,11 @@
+developer: helsinkisystems
+icon: fas fa-file-invoice
+demo: false
+subscription: 149 €
+lemonsqueezy: "https://helsinkisystems.lemonsqueezy.com/checkout/buy/f374aa3a-91b3-4771-9dd6-baaf7965d75d"
+bundle:
+    name: "UserReporting"
+    purchase: true
+    versions:
+        - [ "1.0", "2.0" ]
+

--- a/_includes/store/helsinkisystems-userreporting.md
+++ b/_includes/store/helsinkisystems-userreporting.md
@@ -1,0 +1,17 @@
+## Description
+
+A detailed user reporting bundle. It generates a more detailed report about what projects, activities and customers take up how many time and what budget.
+
+## Installation
+
+This plugin does not need a database table, so there is no installation of the plugin necessary.
+However, it comes with an automated email reportingfunctionality at the end of the month. To enable this, you have to run the following command:
+```
+php bin/console kimai:bundle:userreporting:monthlyreminder
+```
+{% include composer-update-warning.html %}
+
+## Support
+
+If you need help setting this plugin up or have any feature requests our commercial support is available at [kunden@helsinki-systems.de](mailto:kunden@helsinki-systems.de)
+


### PR DESCRIPTION
Added the UserReportingBundle to the store. This allows for a more detailed report for specific users, teams or the whole company on a activity, project and customer level.