### PR TITLE
feat: buy_link field for non vendor-specific shop links for plugin pu…

### DIFF
--- a/_layouts/store-item.html
+++ b/_layouts/store-item.html
@@ -56,6 +56,9 @@ layout: default
     {% assign buyLink = settings.github | append: '/releases' %}
     {% assign buyBtnIcon = 'bx bxl-github' %}
     {% assign buyTitle = site.data[page.lang].translation.download-btn %}
+{% elsif settings.buy_link %}
+    {% assign buyLink = settings.buy_link %}
+    {% assign buyBtnIcon = 'bx bx-cart' %}
 {% endif %}
 
 {% assign isFree = false %}

--- a/plugins.json
+++ b/plugins.json
@@ -25,6 +25,8 @@ permalink: /plugins.json
         "buy": "{{ settings.gumroad }}",
         {%- elsif settings.lemonsqueezy != nil %}
         "buy": "{{ settings.lemonsqueezy }}",
+        {%- elsif settings.buy_link != nil %}
+        "buy": "{{ settings.buy_link }}",
         {%- endif %}
         "developer": {
             "name": "{{ developer.name }}",


### PR DESCRIPTION
…rchase

Related: https://github.com/kimai/www.kimai.org/issues/476

Intended for custom plugin buy links that are **not** vendor-specific.

Hint: Does not work if `settings.multi_purchase` is set to `true` (since this seems to require a gumroad link). See: https://github.com/kimai/www.kimai.org/blob/95145599bbd5c30d5a4bdeb81b56076246d0ecdf/_layouts/store-item.html#L214).