### PR TITLE
Corrected misspelling of the Russian language

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -123,7 +123,7 @@ language_names:
     pl: Polski
     pt: Português
     pt_BR: Português (Brasil)
-    ru: Rусский
+    ru: Русский
     sk: Slovenčina
     sv: Svenska
     uk: Українська


### PR DESCRIPTION
The correct spelling of the Russian language, in Russian, is Русский.