### PR TITLE
Add Kimai Mobile Setup Plugin to the Kimai Store

### DIFF
--- a/_data/developer.yml
+++ b/_data/developer.yml
@@ -85,7 +85,7 @@ cloudrizon:
     name: Cloudrizon GmbH
     description: IT company from Germany
     image: /images/marketplace/cloudrizon-logo.webp
-    homepage: https://cloudrizon.de/
+    homepage: https://www.cloudrizon.com/
     username: Cloudrizon
     profile: "#"
 

--- a/_data/en/store.yml
+++ b/_data/en/store.yml
@@ -8,6 +8,9 @@ items:
     cloudrizon-kimai-mobile-app-ios:
         title: Kimai Mobile (iOS)
         intro: Access Kimai from your iOS device with Kimai Mobile
+    cloudrizon-kimai-mobile-setup-bundle:
+        title: Kimai Mobile Setup
+        intro: Enables an easy way to configure your workspace in the Kimai Mobile app using QR code.
     district09-archive-timesheets-command-bundle:
         title: Archive timesheets command
         intro: A plugin, which allows you to archive timesheets older than a specified timeframe, using a command.

--- a/_data/store/cloudrizon-kimai-mobile-setup-bundle.yml
+++ b/_data/store/cloudrizon-kimai-mobile-setup-bundle.yml
@@ -1,0 +1,8 @@
+developer: "cloudrizon"
+icon: fas fa-mobile-screen
+price: 0
+github: "https://github.com/cloudrizon/kimai-mobile-setup-bundle"
+tags: [plugin]
+bundle:
+    name: "KimaiMobileSetupBundle"
+    download: "https://github.com/cloudrizon/kimai-mobile-setup-bundle.git"

--- a/_includes/store/cloudrizon-kimai-mobile-setup-bundle.md
+++ b/_includes/store/cloudrizon-kimai-mobile-setup-bundle.md
@@ -1,0 +1,3 @@
+## Description
+
+Kimai Mobile Setup plugin provides an easy way to configure your workspace in the [Kimai Mobile](https://www.kimaimobile.com/) app. This plugin enables a new "Kimai Mobile Setup" screen where you can generate an API token and view its corresponding QR code. Simply scan the QR code using the Kimai Mobile app to set up your workspace effortlessly.

--- a/collections/_store/cloudrizon-kimai-mobile-setup-bundle.md
+++ b/collections/_store/cloudrizon-kimai-mobile-setup-bundle.md
@@ -1,0 +1,7 @@
+---
+title: Kimai Mobile Setup
+type: plugin
+lang: en
+---
+
+{% include store/cloudrizon-kimai-mobile-setup-bundle.md %}


### PR DESCRIPTION
Add an entry for the Kimai Mobile Setup plugin to the Kimai Plugin store. It is a plugin that could be used by Kimai Mobile app users to easily setup a workspace using QR code.