### PR TITLE
Add store listing: Jira worklog sync (hilfor)

### DIFF
--- a/_data/de/store.yml
+++ b/_data/de/store.yml
@@ -164,6 +164,9 @@ items:
     engazan-kimaitray:
         title: KimaiTray
         intro: System tray companion app for Kimai on macOS, Windows, and Linux
+    jira-sync:
+        title: Jira-Worklog-Synchronisation
+        intro: Zeiterfassungseinträge mit einem Jira-Vorgang verknüpfen und als Jira-Worklog synchronisieren.
 screenshots:
     expenses-bundle4:
         description: Sie können einen Namen, den Kostenfaktor und einen kurzen Hilfetext für jede Kategorie vergeben

--- a/_data/de/store.yml
+++ b/_data/de/store.yml
@@ -164,6 +164,9 @@ items:
     engazan-kimaitray:
         title: KimaiTray
         intro: Begleit-App für Kimai in der Taskleiste unter macOS, Windows und Linux
+    jira-sync:
+        title: Jira-Worklog-Synchronisation
+        intro: Zeiterfassungseinträge mit einem Jira-Vorgang verknüpfen und als Jira-Worklog synchronisieren.
 screenshots:
     expenses-bundle4:
         description: Sie können einen Namen, den Kostenfaktor und einen kurzen Hilfetext für jede Kategorie vergeben

--- a/_data/developer.yml
+++ b/_data/developer.yml
@@ -264,3 +264,9 @@ engazan:
     image: https://avatars.githubusercontent.com/Engazan
     github: https://github.com/Engazan
     linkedin: https://www.linkedin.com/in/engazan
+hilfor:
+    name: Hilfor
+    description: Independent Kimai plugin developer
+    homepage: https://www.hilfor.biz
+    github: https://github.com/hilfor
+    email: kimai-support@hilfor.biz

--- a/_data/developer.yml
+++ b/_data/developer.yml
@@ -284,3 +284,9 @@ engazan:
     image: https://avatars.githubusercontent.com/Engazan
     github: https://github.com/Engazan
     linkedin: https://www.linkedin.com/in/engazan
+hilfor:
+    name: Hilfor
+    description: Independent Kimai plugin developer
+    homepage: https://www.hilfor.biz
+    github: https://github.com/hilfor
+    email: kimai-support@hilfor.biz

--- a/_data/en/store.yml
+++ b/_data/en/store.yml
@@ -164,6 +164,9 @@ items:
     kloudshift-klockshift:
         title: KlockShift - Bexio Integration for Swiss Businesses
         intro: KlockShift bridges Kimai and Bexio by automatically syncing your time entries into Bexio invoice data. Purpose-built for Swiss freelancers and SMEs.
+    jira-sync:
+        title: Jira worklog sync
+        intro: Tag timesheets with a Jira issue key and sync tracked time to Jira as worklogs.
 screenshots:
     katjaglass-approval-bundle0:
         description: Displays week details like working time, expected time and actions like submit for approval

--- a/_data/screenshots.yml
+++ b/_data/screenshots.yml
@@ -238,3 +238,13 @@ kloudshift-klockshift-4:
     src: "/images/marketplace/kloudshift/klockshift-4.png"
 kloudshift-klockshift-5:
     src: "/images/marketplace/kloudshift/klockshift-5.png"
+jira-sync0:
+    src: "https://hilfor.github.io/kimai-jira-docs/img/timesheet-field.png"
+jira-sync1:
+    src: "https://hilfor.github.io/kimai-jira-docs/img/settings-page.png"
+jira-sync2:
+    src: "https://hilfor.github.io/kimai-jira-docs/img/dashboard-widget.png"
+jira-sync3:
+    src: "https://hilfor.github.io/kimai-jira-docs/img/project-jira-keys.png"
+jira-sync4:
+    src: "https://hilfor.github.io/kimai-jira-docs/img/dashboard-import-warning.png"

--- a/_data/store/jira-sync.yml
+++ b/_data/store/jira-sync.yml
@@ -1,0 +1,18 @@
+developer: hilfor
+icon: fab fa-jira
+demo: false
+subscription: 49 €
+shop: "https://buy.stripe.com/00wbJ32Bhfyo0AQevdefC01"
+documentation: "https://hilfor.github.io/kimai-jira-docs/"
+changelog: true
+tags: [plugin]
+bundle:
+    name: "JiraBundle"
+    command: "kimai:bundle:jira:install"
+    purchase: true
+screenshots:
+    - jira-sync0
+    - jira-sync1
+    - jira-sync2
+    - jira-sync3
+    - jira-sync4

--- a/_data/store/releases/JiraBundle.yaml
+++ b/_data/store/releases/JiraBundle.yaml
@@ -1,0 +1,11 @@
+# Fragment for kimai/www.kimai.org's _data/store/releases/JiraBundle.yaml.
+#
+# Drives the "Updates" tab on the store listing page (requires `changelog: true` in
+# ../jira-sync.yml). Named by the BUNDLE name (JiraBundle), NOT the store slug (jira-sync) - the
+# theme looks the release file up by the `bundle.name` value.
+#
+# Each entry is [plugin version, minimum Kimai version it supports], newest first. The minimum
+# Kimai version mirrors this plugin's own `extra.kimai.require` in composer.json (22100 = 2.21.0),
+# expressed here as the dotted version the store displays.
+versions:
+    - [1.0.0, 2.21.0]

--- a/_includes/store/jira-sync.md
+++ b/_includes/store/jira-sync.md
@@ -1,0 +1,52 @@
+Adds a Jira issue field to every timesheet entry and syncs tracked time to Jira as worklogs,
+authenticated with each user's own personal access token (Jira Server / Data Center) or API
+token (Jira Cloud).
+
+## Features
+
+- An optional **Jira issue** field (e.g. `PROJ-123`) on every timesheet entry, validated and
+  shown as an optional column in timesheet tables and exports - where it renders as a
+  **clickable link** straight to the ticket in Jira.
+- **Live validation**: as you type an issue key on the timesheet form, the plugin confirms it
+  exists in Jira and shows its summary, so a typo never silently syncs to a non-existent issue
+  (advisory only - it never blocks saving).
+- Automatic **create / update / delete** of the matching Jira worklog when a timesheet entry is
+  stopped, edited, or removed - or manual-only sync, your choice. Optionally sync the timesheet
+  description as the worklog comment, or time only.
+- Optional **reverse import** (`kimai:jira:import`): pull each user's own Jira worklogs back into
+  Kimai as timesheets, so time logged in Jira shows up in Kimai reports too - opt-in, matched by
+  each user's own token, and de-duplicated so re-runs never create doubles.
+- Each user manages their **own** Jira credential on a personal settings page, with a
+  "Test connection" button that reports a specific, worded result (rejected credentials, DNS,
+  TLS, timeout - each is different and has a different fix).
+- Tokens are **encrypted at rest** (libsodium) in their own database table - never in a Kimai
+  user preference, never returned by any API.
+- **Resilient by design**: saving a timesheet never waits on Jira, a background reconciler
+  (`kimai:jira:sync`, meant to run from cron) drains anything that could not sync inline, and an
+  expired token is caught by a daily heartbeat check instead of silently going stale.
+- Works against both **Jira Cloud** and **Jira Server / Data Center** (Bearer or Basic auth,
+  configured per customer - so different customers can run different Jira instances).
+
+## Installation
+
+Checkout the plugin into `var/plugins/JiraBundle` and clear the cache.
+
+Run `bin/console kimai:bundle:jira:install` to create the plugin's own database table.
+
+## Usage
+
+Configure the Jira server URL and authentication mode **on each customer** (Customers \> edit a
+customer \> Jira; admin only) - so customers on different Jira instances each get their own. Each
+user then opens **Jira settings** from their user menu and stores a personal access token / API
+token per customer. From then on, filling in the **Jira issue** field on a timesheet entry is all
+it takes - the worklog appears on the referenced Jira issue (the one for that timesheet's customer)
+once the entry is stopped or saved with an end time.
+
+See the [documentation](https://hilfor.github.io/kimai-jira-docs/) for the full configuration reference,
+including Jira Cloud vs. Server/Data Center setup, per-project routing and auto-create, the
+optional `kimai:jira:import` reverse importer and custom-field passthrough, and the cron entries
+the background reconciler and importer need.
+
+## Support
+
+Setup help, bug reports and feature requests: [kimai-support@hilfor.biz](mailto:kimai-support@hilfor.biz). The full configuration reference lives in the [documentation](https://hilfor.github.io/kimai-jira-docs/).

--- a/collections/_store/jira-sync.md
+++ b/collections/_store/jira-sync.md
@@ -1,0 +1,6 @@
+---
+title: Jira worklog sync
+type: plugin
+---
+
+{% include store/jira-sync.md %}


### PR DESCRIPTION
Adds a store listing for **Jira worklog sync**, a paid third-party plugin by Hilfor.

The plugin adds an optional Jira issue field to timesheet entries and syncs tracked time to Jira as worklogs (Jira Cloud and Server / Data Center), authenticated per user with a personal access / API token. It also offers an optional reverse importer for pulling Jira worklogs back into Kimai.

### What this PR adds
- `_data/store/jira-sync.yml` — paid listing (`bundle.purchase: true`, 49 €/yr subscription, Stripe checkout)
- `_data/developer.yml` — `hilfor` developer entry
- `_data/en/store.yml`, `_data/de/store.yml` — title + intro (EN / DE)
- `_includes/store/jira-sync.md` — long description
- `collections/_store/jira-sync.md` — rendered listing page
- `_data/screenshots.yml` — five screenshots served from the public docs site
- `_data/store/releases/JiraBundle.yaml` — Updates tab (Kimai compatibility history)

### Notes
- Source is closed; the plugin ships as a purchased ZIP extracted into `var/plugins/JiraBundle`, so there is no public `clone` URL.
- Documentation and all screenshots are hosted publicly at <https://hilfor.github.io/kimai-jira-docs/> — no image files are added to this repo.
- Modeled on the existing paid third-party listings.
