### PR TITLE
docs: add Zenith Hosting to 1-click hosting options

### DIFF
--- a/collections/_documentation/hosting-1-click.md
+++ b/collections/_documentation/hosting-1-click.md
@@ -53,3 +53,11 @@ Read [this issue]({{ site.kimai_v2_repo }}/issues/743) if you have further quest
 ### ISPConfig 3
 
 There is an installation doc (only in German) available at [www.howtoforge.de](https://www.howtoforge.de/anleitung/installation-kimai2-webbasierte-zeiterfassung-in-einem-ispconfig3-web/).
+
+### Zenith
+
+[Zenith](https://zenith.hosting/host/kimai) provides one-click, fully managed Kimai hosting, so you don't need your own server or any DevOps knowledge.
+Every instance includes storage, automatic backups, outgoing email, and a free subdomain, and you can connect your own domain later.
+A share of every subscription goes back to the Kimai project to help fund its development.
+
+[Deploy Kimai with Zenith](https://zenith.hosting/host/kimai){: .btn .btn-success}


### PR DESCRIPTION
hey, following up on kimai/kimai#6041 — thanks @kevinpapst. as requested, moving the Zenith entry here to the 1-click hosting page (CLA now signed on the main repo).

this adds one entry at the end of `hosting-1-click.md` for Zenith Hosting, a startup doing one-click managed hosting for open source apps. what makes it different: fully managed Kimai with storage, automatic backups, outgoing email and a free subdomain included, no server or devops needed, and a share of every subscription goes back to the Kimai project.

matched the existing `###` heading + description + `.btn .btn-success` button format. happy to adjust the wording. hello@zenith.hosting
