### PR TITLE
Shorter duration entry documentation

### DIFF
--- a/_includes/snippets/duration_format.md
+++ b/_includes/snippets/duration_format.md
@@ -20,6 +20,12 @@ The `{{ fieldName }}` field supports entering data in the following formats:
 - Description: Duration in hours, for decimal separator both `.`  and `,` are supported, minutes need to be given as decimal portion (eg. 30 minutes = 0.5)
 - Examples: `1,5` = 1 hour and 30 minutes, `2` = 2 hours
 
+#### Integer duration
+
+- Format: `{duration}` (a plain number, no decimal point or letter)
+- Description:  Integers lower than 10 are interpreted as hours, greater or equal 10 as minutes
+- Examples: `2` = 2 hours, `15` = 15 minutes
+
 #### Duration drop-down
 
 If activated in [System → Settings]({% link _documentation/configurations.md %}), the duration field has a dropdown.


### PR DESCRIPTION
Added section for "plain" integer duration format and examples.

This adds documentation for the code in https://github.com/kimai/kimai/pull/6146 .